### PR TITLE
[Fix] #24 Illegal base64url character: ' ' 오류 수정 완료

### DIFF
--- a/src/main/java/mju/capstone/cms/domain/auth/jwt/provider/JwtProvider.java
+++ b/src/main/java/mju/capstone/cms/domain/auth/jwt/provider/JwtProvider.java
@@ -92,7 +92,9 @@ public class JwtProvider implements InitializingBean {
     /**
      * token validation
      */
-    public boolean validateToken(String token) {
+    public boolean validateToken(String bearerToken) {
+        //토큰 추출. jwtFiler에서 Bearer enhj... 그대로 써서 오류났었음.
+        String token = extractToken(bearerToken);
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;


### PR DESCRIPTION
Illegal base64url character: ' ' 오류 수정 완료

JwtFilter에서 Bearer enyasdf... 그대로 넘겨서 오류
JwtProvider에서 알아서 추출해서 인증하게됨.

close #24 