### PR TITLE
[Fix] #42 쉬는 시간 관련 수정

### DIFF
--- a/src/main/java/mju/capstone/cms/domain/emotion/repository/EmotionRepository.java
+++ b/src/main/java/mju/capstone/cms/domain/emotion/repository/EmotionRepository.java
@@ -1,6 +1,7 @@
 package mju.capstone.cms.domain.emotion.repository;
 
 import mju.capstone.cms.domain.emotion.entity.Emotion;
+import mju.capstone.cms.domain.student.entity.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,7 +18,6 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
     @Query("SELECT e FROM Emotion e JOIN e.subject s JOIN e.student st WHERE s.id = :subjectId AND e.date BETWEEN :startDate AND :endDate AND st.id = :studentId")
     Emotion findBySubjectIdAndStudentIdAndDateBetween(@Param("subjectId") Long subjectId, @Param("studentId") String studentId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
-
-    @Query("SELECT e FROM Emotion e  JOIN e.student st WHERE  e.date BETWEEN :startDate AND :endDate AND st.id = :studentId")
-    List<Emotion> findByStudentIdAndDateBetween(@Param("studentId") String studentId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+    @Query("SELECT e FROM Emotion e JOIN e.subject s WHERE s.subjectName = '쉬는시간' AND e.date BETWEEN :startDate AND :endDate AND e.student = :student")
+    List<Emotion> findRecessListByStudentAndDateBetween(@Param("student") Student student, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/mju/capstone/cms/domain/student/entity/Student.java
+++ b/src/main/java/mju/capstone/cms/domain/student/entity/Student.java
@@ -48,7 +48,11 @@ public class Student {
         studentDto.setId(this.id);
         studentDto.setName(this.name);
         studentDto.setTeacherId(this.teacher.getId());
-        studentDto.setParentId(this.parent.getId());
+        try {
+            studentDto.setParentId(this.parent.getId());
+        } catch (NullPointerException e) {
+            studentDto.setParentId(null);
+        }
         return studentDto;
     }
 

--- a/src/main/java/mju/capstone/cms/domain/student/service/StudentService.java
+++ b/src/main/java/mju/capstone/cms/domain/student/service/StudentService.java
@@ -175,7 +175,11 @@ public class StudentService {
             Emotion emotion;
             try {
                 emotion = emotionRepository.findBySubjectIdAndStudentIdAndDateBetween(subjectId, studentId, monday1, monday1);
-                interestRateList.add(emotion.getHappy());
+                Focus focus = focusRepository.findBySubjectIdAndStudentIdAndDateBetween(subjectId, emotion.getStudent().getId(), monday1, monday1);
+                double interestScore = (emotion.getHappy() + emotion.getNeutral() + emotion.getSurprise() - emotion.getAngry() - emotion.getDisgust() - emotion.getFear() - emotion.getSad() + 1) * 50;
+                double focusScore = focus.getFocusRate();
+                double result = (interestScore + focusScore) / 2;
+                interestRateList.add(result);
             } catch (NullPointerException e) {
                 interestRateList.add(0.0);
             }

--- a/src/main/java/mju/capstone/cms/domain/subject/Repository/SubjectRepository.java
+++ b/src/main/java/mju/capstone/cms/domain/subject/Repository/SubjectRepository.java
@@ -3,9 +3,11 @@ package mju.capstone.cms.domain.subject.Repository;
 import mju.capstone.cms.domain.subject.entity.Subject;
 import mju.capstone.cms.domain.teacher.entity.Teacher;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
+    @Query("SELECT s FROM Subject s WHERE s.subjectName <> '쉬는시간' And s.teacher = :teacher")
     List<Subject> findByTeacher(Teacher teacher);
 }

--- a/src/main/java/mju/capstone/cms/domain/teacher/Service/TeacherService.java
+++ b/src/main/java/mju/capstone/cms/domain/teacher/Service/TeacherService.java
@@ -5,14 +5,11 @@ import mju.capstone.cms.domain.emotion.entity.Emotion;
 import mju.capstone.cms.domain.emotion.repository.EmotionRepository;
 import mju.capstone.cms.domain.focus.entity.Focus;
 import mju.capstone.cms.domain.focus.repository.FocusRepository;
-import mju.capstone.cms.domain.student.dto.StudentDto;
-import mju.capstone.cms.domain.student.entity.Student;
 import mju.capstone.cms.domain.student.repository.StudentRepository;
 import mju.capstone.cms.domain.subject.dto.SubjectFocusRateDto;
 import mju.capstone.cms.domain.subject.Repository.SubjectRepository;
 import mju.capstone.cms.domain.subject.entity.Subject;
 import mju.capstone.cms.domain.teacher.Repository.TeacherRepository;
-import mju.capstone.cms.domain.teacher.dto.TeacherSignupResponseDto;
 import mju.capstone.cms.domain.teacher.entity.Teacher;
 import org.springframework.stereotype.Service;
 
@@ -32,7 +29,6 @@ public class TeacherService {
     private final TeacherRepository teacherRepository;
     private final FocusRepository focusRepository;
     private final EmotionRepository emotionRepository;
-    private final StudentRepository studentRepository;
 
     // 수업 관리
     public List<SubjectFocusRateDto> manageClass(String teacherId, int week) {
@@ -50,6 +46,7 @@ public class TeacherService {
         subjectList.stream().forEach(s -> System.out.println(s.getSubjectName()));
 
         // 과목 객체
+        // -> 쉬는 시간은 나오면 안됨
         for (Subject subject : subjectList) {
             SubjectFocusRateDto SubjectFocusRate = new SubjectFocusRateDto();
             SubjectFocusRate.setSubjectName(subject.getSubjectName());
@@ -57,7 +54,7 @@ public class TeacherService {
             SubjectFocusRate.setFocusRate(calcWeekFocus(week, subject.getId()));
             // 흥미도
             SubjectFocusRate.setInterestRate(calcWeekinterest(week, subject.getId()));
-            
+
             SubjectFocusRateList.add(SubjectFocusRate);
         }
 
@@ -90,8 +87,8 @@ public class TeacherService {
         List<Double> focusRateList = new ArrayList<>();
 
         // 일주일 치 (5일) 반복
-        for (int i=0; i<5; i++) {
-            cal.add(Calendar.DATE, Calendar.MONDAY+i - (cal.get(Calendar.DAY_OF_WEEK)));
+        for (int i = 0; i < 5; i++) {
+            cal.add(Calendar.DATE, Calendar.MONDAY + i - (cal.get(Calendar.DAY_OF_WEEK)));
             System.out.println("월요일 날짜 : " + sdf.format(cal.getTime()));
             LocalDate monday1 = LocalDate.ofInstant(cal.toInstant(), ZoneId.systemDefault());
             List<Focus> focusList = focusRepository.findBySubjectIdAndDateBetween(subjectId, monday1, monday1);
@@ -137,8 +134,8 @@ public class TeacherService {
         List<Double> interestRateList = new ArrayList<>();
 
         // 일주일 치 (5일) 반복
-        for (int i=0; i<5; i++) {
-            cal.add(Calendar.DATE, Calendar.MONDAY+i - (cal.get(Calendar.DAY_OF_WEEK)));
+        for (int i = 0; i < 5; i++) {
+            cal.add(Calendar.DATE, Calendar.MONDAY + i - (cal.get(Calendar.DAY_OF_WEEK)));
             System.out.println("월요일 날짜 : " + sdf.format(cal.getTime()));
             LocalDate monday1 = LocalDate.ofInstant(cal.toInstant(), ZoneId.systemDefault());
             List<Emotion> emotionList = emotionRepository.findBySubjectIdAndDateBetween(subjectId, monday1, monday1);
@@ -162,25 +159,23 @@ public class TeacherService {
 
         return interestRateList;
     }
-    
-    
 
     //회원가입
     public Teacher signup(String id, String password, String name, String school) {
 
         //이미 있는 아이디 -> 예외
         teacherRepository.findById(id)
-            .ifPresent(teacher -> {
-                throw new IllegalStateException("teacher already exists");
-            });
+                .ifPresent(teacher -> {
+                    throw new IllegalStateException("teacher already exists");
+                });
 
 
         Teacher t = Teacher.builder()
-            .id(id)
-            .password(password)
-            .name(name)
-            .school(school)
-            .build();
+                .id(id)
+                .password(password)
+                .name(name)
+                .school(school)
+                .build();
 
         Teacher teacher = teacherRepository.save(t);
 
@@ -194,6 +189,8 @@ public class TeacherService {
         subjectRepository.save(society);
         Subject science = Subject.builder().subjectName("과학").teacher(teacher).build();
         subjectRepository.save(science);
+        Subject recess = Subject.builder().subjectName("쉬는시간").teacher(teacher).build();
+        subjectRepository.save(recess);
 
         return teacher;
     }
@@ -214,15 +211,15 @@ public class TeacherService {
 //        cal.setTime(date);
         cal.add(Calendar.DATE, -(week * 7));
 
-        System.out.println("오늘 날짜: " + sdf.format(cal.getTime()));
+//        System.out.println("오늘 날짜: " + sdf.format(cal.getTime()));
 
         cal.add(Calendar.DATE, Calendar.MONDAY - (cal.get(Calendar.DAY_OF_WEEK)));
-        System.out.println("월요일 날짜 : " + sdf.format(cal.getTime()));
+//        System.out.println("월요일 날짜 : " + sdf.format(cal.getTime()));
         LocalDate monday = LocalDate.ofInstant(cal.toInstant(), ZoneId.systemDefault());
 
 //        cal.setTime(date);
         cal.add(Calendar.DATE, Calendar.FRIDAY - (cal.get(Calendar.DAY_OF_WEEK)));
-        System.out.println("금요일 날짜 : " + sdf.format(cal.getTime()));
+//        System.out.println("금요일 날짜 : " + sdf.format(cal.getTime()));
         LocalDate friday = LocalDate.ofInstant(cal.toInstant(), ZoneId.systemDefault());
 
         // 한 과목에 대해서만 집중 객체들 (subject id == 1)
@@ -250,15 +247,15 @@ public class TeacherService {
 //        cal.setTime(date);
         cal.add(Calendar.DATE, -(week * 7));
 
-        System.out.println("오늘 날짜: " + sdf.format(cal.getTime()));
+//        System.out.println("오늘 날짜: " + sdf.format(cal.getTime()));
 
         cal.add(Calendar.DATE, Calendar.MONDAY - (cal.get(Calendar.DAY_OF_WEEK)));
-        System.out.println("월요일 날짜 : " + sdf.format(cal.getTime()));
+//        System.out.println("월요일 날짜 : " + sdf.format(cal.getTime()));
         LocalDate monday = LocalDate.ofInstant(cal.toInstant(), ZoneId.systemDefault());
 
 //        cal.setTime(date);
         cal.add(Calendar.DATE, Calendar.FRIDAY - (cal.get(Calendar.DAY_OF_WEEK)));
-        System.out.println("금요일 날짜 : " + sdf.format(cal.getTime()));
+//        System.out.println("금요일 날짜 : " + sdf.format(cal.getTime()));
         LocalDate friday = LocalDate.ofInstant(cal.toInstant(), ZoneId.systemDefault());
 
         // 한 과목에 대해서만 집중 객체들 (subject id == 1)
@@ -281,7 +278,7 @@ public class TeacherService {
         Calendar cal = Calendar.getInstance(Locale.KOREA);
         cal.setTime(date);
 
-        System.out.println("입력 날짜: " + sdf.format(cal.getTime()));
+//        System.out.println("입력 날짜: " + sdf.format(cal.getTime()));
         LocalDate today = LocalDate.ofInstant(cal.toInstant(), ZoneId.systemDefault());
         return focusRepository.findBySubjectIdAndDateBetween(subjectId, today, today);
     }
@@ -296,7 +293,7 @@ public class TeacherService {
         Calendar cal = Calendar.getInstance(Locale.KOREA);
         cal.setTime(date);
 
-        System.out.println("입력 날짜: " + sdf.format(cal.getTime()));
+//        System.out.println("입력 날짜: " + sdf.format(cal.getTime()));
         LocalDate today = LocalDate.ofInstant(cal.toInstant(), ZoneId.systemDefault());
         List<Focus> focusList = focusRepository.findBySubjectIdAndDateBetween(subjectId, today, today);
 


### PR DESCRIPTION
1. parent id는 기본이 null인데 유저 모든 학생 조회 시 학부모 없으면 500 뜨는 에러 수정
2. 아직 출석 안한날은 3으로 보내기 (디폴트 값을 3) -> 프론트와 논의 완료
3. 쉬는 시간 객체 4개인데 합쳐서 평균 감정 반환
4. 교사 가입 시 생성되는 과목에 쉬는 시간도 추가